### PR TITLE
Fix profiling script import side effect

### DIFF
--- a/profile_sa_solver.py
+++ b/profile_sa_solver.py
@@ -1,4 +1,3 @@
-print("Profiler script started...") # ADD THIS LINE
 import os
 import sys
 import time # Add time for measuring execution
@@ -114,6 +113,7 @@ def run_sa_experiments():
     #         log.error(f"Error running exact_model for n=6: {e}")
 
 if __name__ == "__main__":
+    print("Profiler script started...")
     project_root = os.path.dirname(os.path.abspath(__file__))
     os.chdir(project_root)
     


### PR DESCRIPTION
## Summary
- remove top-level print from `profile_sa_solver.py`
- print start message only when run as a script

## Testing
- `python -m py_compile profile_sa_solver.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840918b37f883328b887ac571c8cd68